### PR TITLE
Custom port specification and fixed asymmetric crypto for python3

### DIFF
--- a/onion_router/onion_router.py
+++ b/onion_router/onion_router.py
@@ -29,6 +29,7 @@ HOST = ""
 LISTENER_SOCKET = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 LISTENER_SOCKET.bind((HOST,PORT))
 LISTENER_SOCKET.listen(50)
+DEFAULT_NEXT_PORT = 80
 
 
 
@@ -56,6 +57,8 @@ def main():
 
 # need to establish symkey with back_conn, connect to forw_conn
 def two_way_setup(back_conn):
+    global DEFAULT_NEXT_PORT
+
     msg = back_conn.recv(2048).decode('utf-8').rstrip()
 
     # (TODO:decrypt data, initialize+respond with symkey. for now send 'ACK')
@@ -72,11 +75,16 @@ def two_way_setup(back_conn):
     msg_dict = json.loads(msg)
     msg_data = msg_dict["data"]
     msg_addr = msg_dict["addr"]
+    
+    if "port" in msg_dict:
+        port = msg_dict["port"]
+    else:
+        port = DEFAULT_NEXT_PORT
 
     # connect to forw_conn and pass along data from back_conn
     forw_conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     print('[Onion] Connecting to next onion node...')
-    forw_conn.connect((msg_addr, PORT))
+    forw_conn.connect((msg_addr, port))
     print('[Onion] Connected.')
     forw_conn.send(json.dumps(msg_data).encode('utf-8'))
 

--- a/onion_router/onion_router.py
+++ b/onion_router/onion_router.py
@@ -57,8 +57,6 @@ def main():
 
 # need to establish symkey with back_conn, connect to forw_conn
 def two_way_setup(back_conn):
-    global DEFAULT_NEXT_PORT
-
     msg = back_conn.recv(2048).decode('utf-8').rstrip()
 
     # (TODO:decrypt data, initialize+respond with symkey. for now send 'ACK')

--- a/stealth/jmsg.py
+++ b/stealth/jmsg.py
@@ -1,11 +1,12 @@
 import json
 
 class JSONMessage(object):
-    def __init__(self, message_type, addr, msg):
+    def __init__(self, message_type, addr, msg, port=80):
         self.d = {}
         self.d["data"] = msg
         self.d["addr"] = addr
         self.d["type"] = str(message_type)
+        self.d["port"] = port
     
     def to_string(self):
         return json.dumps(self.d)

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -42,10 +42,6 @@ class Originator(object):
 
     # Creates the full encryption-layered message
     def create_onion(self, mtype, depth, msg, dst, dstPort=80):
-#        msg = { #Greasy switch implementation with dictionary
-#            MessageType.Data: JSONMessage("Data", dst, msg), 
-#            MessageType.Establish: JSONMessage("Establish", dst, self.create_symkey_msg(depth))
-#            }[mtype]
         if mtype == MessageType.Data: msg = JSONMessage("Data", dst, msg, dstPort)
         elif mtype == MessageType.Establish: msg = JSONMessage("Establish", dst, self.create_symkey_msg(depth), dstPort)
         for i in range(depth-1,0,-1): # Cycles list in reverse order
@@ -66,7 +62,6 @@ class Originator(object):
 
     def create_symkey_msg(self, depth):
         msg = {}
-        print('DEBUG: ' + repr(self.path[depth-1][1]))
         sym = self.path[depth-1][1]
         enc_sym = self.pubkeys[depth-1].encrypt(sym)
         msg["symkey"] = base64.encodestring(enc_sym[0]).decode('utf-8')

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -64,9 +64,9 @@ class Originator(object):
         msg = {}
         sym = self.path[depth-1][1]
         enc_sym = self.pubkeys[depth-1].encrypt(sym)
-        msg["symkey"] = base64.encodestring(enc_sym[0]).decode('utf-8')
-        if(depth == 1): msg["prevKey"] = base64.encodestring(self.pubkeys[depth-1].encrypt(self.key)[0]).decode('utf-8')
-        else: msg["prevKey"] = base64.encodestring(self.pubkeys[depth-1].encrypt(self.path[depth-2][1])[0]).decode('utf-8')
+        msg["symkey"] = base64.encodebytes(enc_sym[0]).decode('utf-8')
+        if(depth == 1): msg["prevKey"] = base64.encodebytes(self.pubkeys[depth-1].encrypt(self.key)[0]).decode('utf-8')
+        else: msg["prevKey"] = base64.encodebytes(self.pubkeys[depth-1].encrypt(self.path[depth-2][1])[0]).decode('utf-8')
         return json.dumps(msg)
 
     def set_pubkeys(self, keys):

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -41,13 +41,13 @@ class Originator(object):
         return self.path
 
     # Creates the full encryption-layered message
-    def create_onion(self, mtype, depth, msg=None, dst=None):
+    def create_onion(self, mtype, depth, msg, dst, dstPort=80):
 #        msg = { #Greasy switch implementation with dictionary
 #            MessageType.Data: JSONMessage("Data", dst, msg), 
 #            MessageType.Establish: JSONMessage("Establish", dst, self.create_symkey_msg(depth))
 #            }[mtype]
-        if mtype == MessageType.Data: msg = JSONMessage("Data", dst, msg)
-        elif mtype == MessageType.Establish: msg = JSONMessage("Establish", dst, self.create_symkey_msg(depth))
+        if mtype == MessageType.Data: msg = JSONMessage("Data", dst, msg, dstPort)
+        elif mtype == MessageType.Establish: msg = JSONMessage("Establish", dst, self.create_symkey_msg(depth), dstPort)
         for i in range(depth-1,0,-1): # Cycles list in reverse order
             msg = self.add_layer(msg.to_string(), i, False)
         if(mtype == MessageType.Data): msg = self.add_layer(msg.to_string(), 0, True)
@@ -66,15 +66,12 @@ class Originator(object):
 
     def create_symkey_msg(self, depth):
         msg = {}
-#        msg["symkey"] = str(self.pubkeys[depth-1].encrypt(self.path[depth-1][1]))
-#        print('Encrypted symkey, length ' + str(len(msg["symkey"])) + ': ' + msg["symkey"])
-#        if(depth == 1): msg["prevKey"] = str(self.pubkeys[depth-1].encrypt(self.key))
-#        else: msg["prevKey"] = str(self.pubkeys[depth-1].encrypt(self.path[depth-2][1]))
-        msg["symkey"] = base64.b64encode(self.pubkeys[depth-1].encrypt(self.path[depth-1][1])[0])
-#        print('Encrypted symkey, length ' + str(len(msg["symkey"])) + ': ' + msg["symkey"])
-        if(depth == 1): msg["prevKey"] = base64.b64encode(self.pubkeys[depth-1].encrypt(self.key)[0])
-        else: msg["prevKey"] = base64.b64encode(self.pubkeys[depth-1].encrypt(self.path[depth-2][1])[0])
-#        print('created cipher: ' + cipher)
+        print('DEBUG: ' + repr(self.path[depth-1][1]))
+        sym = self.path[depth-1][1]
+        enc_sym = self.pubkeys[depth-1].encrypt(sym)
+        msg["symkey"] = base64.encodestring(enc_sym[0]).decode('utf-8')
+        if(depth == 1): msg["prevKey"] = base64.encodestring(self.pubkeys[depth-1].encrypt(self.key)[0]).decode('utf-8')
+        else: msg["prevKey"] = base64.encodestring(self.pubkeys[depth-1].encrypt(self.path[depth-2][1])[0]).decode('utf-8')
         return json.dumps(msg)
 
     def set_pubkeys(self, keys):

--- a/stealth/test.py
+++ b/stealth/test.py
@@ -19,7 +19,7 @@ class TestOnioning(unittest.TestCase):
         originator = Originator()
         onions = originator.get_onions()
         msg = ''.join([random.choice('abcdefghijklmnopqrstuvwxyz0123456789') for _ in range(0,4096)])
-        packet = originator.create_onion(onion.MessageType.Data, 3,  msg, 'Linus Torvalds')
+        packet = originator.create_onion(onion.MessageType.Data, 3,  msg, 'Linus Torvalds', 80)
 #        print('Originator creates:')
 #        print(packet.to_dict())
 #        print('')
@@ -46,7 +46,7 @@ class TestPublicKeyCrypto(unittest.TestCase):
     def test_basic_rsa(self):
         keypair = RSAVirtuoso()
         sender = RSAVirtuoso(keypair.get_public_key())
-        msg = ''.join([random.choice('abcdefghijklmnopqrstuvwxyz0123456789') for _ in range(0,256)])
+        msg = ''.join([random.choice('abcdefghijklmnopqrstuvwxyz0123456789') for _ in range(0,256)]).encode('utf-8')
         cipher = sender.encrypt(msg)
         self.assertEqual(keypair.decrypt(cipher), msg)
 
@@ -56,7 +56,7 @@ class TestEstablishment(unittest.TestCase):
         originator = Originator()
         originator.set_pubkeys(list(map(lambda x: RSAVirtuoso(x.get_public_key()), nodes)))
         path = originator.get_path()
-        packet = originator.create_onion(onion.MessageType.Establish, 1, '', 0).to_dict()
+        packet = originator.create_onion(onion.MessageType.Establish, 1, '', 0, 80).to_dict()
         addr = int(packet["addr"])
         while packet["type"] != "Establish":
             packet = packet["data"]
@@ -65,7 +65,7 @@ class TestEstablishment(unittest.TestCase):
         keydata = json.loads(packet["data"])
         k = base64.b64decode(keydata["symkey"])
         symkey = nodes[addr].decrypt(k)
-        self.assertEqual(path[addr][1],symkey)
+        self.assertEqual(path[addr][1], symkey)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Pretty simple pull request, but important that what I did here gets merged to master.
* Added custom port specification, so messages may be sent to a server listening on any port (such as an arbitrary website)
* Modified `onion_router/onion_router.py` to connect to the port specified in the `"port"` section of the JSON it receives, or to port 80 if there is no port specified
* Modified `stealth/jmsg.py` and `stealth/onion.py` to reflect these changes
* Fixed public key crypto stuff so that it works with py3. I wrote that part on the trottier machines, which apparently have py2 as default. The py3 crypto library requires different encodings so I had to fight with that for a while. This part really needs to be merged.
* Unit tests in `stealth/` now pass with py2 and py3.

Resolves #15 