### PR TITLE
Directory key transfer 25

### DIFF
--- a/client/onion_client.py
+++ b/client/onion_client.py
@@ -64,11 +64,12 @@ def run_client_node():
     if args.verbose: print('[Status] Setting up VC...')
     if not setup_vc(path, SENDER_SOCKET): raise Exception('[Error] Could not setup VC')
 
-    t = threading.Thread(target=handle_response, args=(SENDER_SOCKET,), daemon=True)
+    t = threading.Thread(target=handle_response, args=(SENDER_SOCKET,))
+    t.setDaemon(True)
     t.start()
 
     # send first data onion 
-    msg = input('Enter Message > ')
+    msg = raw_input('Enter Message > ')
 
     first_onion = encapsulate(path[3]['addr'], path[3]['key'], 
                                 msg, args.destination_port)
@@ -82,7 +83,7 @@ def run_client_node():
     if args.verbose: print('[Status] Virtual Circuit UP')
 
     while True:
-        msg = input('Enter Message > ')
+        msg = raw_input('Enter Message > ')
             
         # TODO encrypt
 

--- a/destination/dummy_dest.py
+++ b/destination/dummy_dest.py
@@ -36,8 +36,8 @@ def main():
     try:
         while 1:
             conn_socket, client_addr = SOCKET_LISTEN.accept()
-            t = threading.Thread(target=reply, 
-                                args=(conn_socket, client_addr), daemon=True)
+            t = threading.Thread(target=reply, args=(conn_socket, client_addr))
+            t.setDaemon(True)
             t.start()
     except KeyboardInterrupt:
         if args.verbose: print('[Error] Destination Node DOWN')

--- a/destination/dummy_dest.py
+++ b/destination/dummy_dest.py
@@ -1,35 +1,37 @@
-import socket
-import argparse
-import threading
-
+import argparse             # for command-line argument parsing
+import socket               # for TCP communication
+import threading            # for one thread per TCP connection
 
 
 #       CLI ARGS
 #########################################################
 
+# define cli positional args
 parser = argparse.ArgumentParser() # instantiate cli args parser
 
-# define cli positional args
 parser.add_argument("port", help="port to listen on", type=int)
 parser.add_argument("-v", "--verbose",
                             help="level of logging verbose", action="store_true")
 
 args = parser.parse_args() # parse the args
 
+# TODO disabled to facilitate testing
 # validate args against conditions
-if args.port < 5551 or args.port > 5557: # 7 group members, each get a port
-    parser.error("port must satisfy: 5551 <= port <= 5557")
+#if args.port < 5551 or args.port > 5557: # 7 group members, each get a port
+#    parser.error("port must satisfy: 5551 <= port <= 5557")
 
 
-
-#       RUN DUMMY SERVER
+#       GLOBALS
 ########################################################
 
-PORT = args.port
 HOST = ""
+PORT = args.port
 SOCKET_LISTEN = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 SOCKET_LISTEN.bind((HOST,PORT))
 SOCKET_LISTEN.listen(1)
+
+#       MAIN
+########################################################
 
 def main():
     if args.verbose: print('[Status] Destination Node UP')
@@ -43,6 +45,10 @@ def main():
         if args.verbose: print('[Error] Destination Node DOWN')
         SOCKET_LISTEN.close()
 
+
+#       HANDLE CONNECTIONS
+########################################################
+
 def reply(conn_socket, addr):
     try:
         while True:
@@ -54,6 +60,11 @@ def reply(conn_socket, addr):
         if args.verbose: print('[Error] Lost communication with {}:{}'
                                 .format(addr[0], str(addr[1])))
         conn_socket.close()
+        SOCKET_LISTEN.close()
+
+
+#       RUN MAIN
+########################################################
 
 if __name__ == "__main__":
     main()

--- a/directory/onion_directory.py
+++ b/directory/onion_directory.py
@@ -4,25 +4,21 @@ import random               # for random path selection
 import socket               # for TCP communication
 import threading            # for one thread per TCP connection
 
-import sys
-import os.path
+import sys, os.path
 sys.path.append(os.path.join(os.path.dirname(__file__), '../stealth'))
-import stealth
+import stealth              # for communication encryption
 
-
-#   TODO:
-#    - incorporate encryption key mgmt
-#    - directory ping of nodes causes routers to fail, must start directory
-#      before router
 
 #   CLI ARGS
 ###############################################################################
 
-parser = argparse.ArgumentParser() # instantiate cli args parser
-
 # define cli positional args
-parser.add_argument("max_nodes", help="qty of nodes in network", type=int)
-parser.add_argument("port", help="port to listen on", type=int)
+parser = argparse.ArgumentParser() 
+
+parser.add_argument("max_nodes", help="Quantity of nodes in network", type=int)
+parser.add_argument("port", help="Port to listen on for path requests", type=int)
+parser.add_argument("dir_port", 
+                    help="Port that routers will listen for Directory", type=int)
 parser.add_argument("-v", "--verbose",
                     help="level of logging verbose", action="store_true")
 
@@ -31,22 +27,22 @@ args = parser.parse_args() # parse the args
 # validate args against conditions
 if args.max_nodes > 50 or args.max_nodes < 1: # no more than 50 nodes
     parser.error("max_nodes must satisfy: 1 <= max_nodes <= 50")
-if args.port < 5551 or args.port > 5557: # 7 group members, each get a port
-    parser.error("port must satisfy: 5551 <= port <= 5557")
-
+# TODO disabled to a facilitate testing
+#if args.port < 5551 or args.port > 5557: # 7 group members, each get a port
+#    parser.error("port must satisfy: 5551 <= port <= 5557")
 
 
 #   GLOBALS
 #################################################################################
 
-HOST = ""                            # empty string => all IPs of this machine
-PORT = args.port                     # port for server to listen on, cli arg
 
-MAX_NODES = args.max_nodes           # max number of nodes in onion network
-NODE_FORMAT = "lab2-{}.cs.mcgill.ca" # python formatstring of nodes' domain names
-NODES = [NODE_FORMAT.format(i) for i in range(1, MAX_NODES+1)]
+KEYPAIR = stealth.RSAVirtuoso()             # directory's encryption key pairs
 
-KEYPAIR = stealth.RSAVirtuoso()              # directory's encryption key pairs
+ROUTERS = []                                # available routers in the onion network
+
+HOST = ""                            
+PORT = args.port                     
+MAX_NODES = args.max_nodes                  # max number of nodes in onion network
 
 LISTEN_SOCKET = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 LISTEN_SOCKET.bind((HOST, PORT))
@@ -57,11 +53,15 @@ LISTEN_SOCKET.listen(MAX_NODES)
 #################################################################################
 
 def main():
-    global NODES
-
+    global ROUTERS
+    
     if args.verbose: print('[Status] Querying network nodes...')
-    NODES = list( filter(ping_node, NODES) ) # keep nodes that respond to ping
-    NODES = list( zip(NODES, map(get_node_pubkey, NODES)) )  # and get pubkeys
+    
+    # build list of available routers with their respective encryption keys
+    nodes = ['lab2-{}'.format(i) for i in range(1, MAX_NODES+1)]
+    up_nodes = list( filter(ping_node, nodes) ) 
+    nodes_keys = zip(up_nodes, map(get_node_pubkey, up_nodes))
+    ROUTERS = [{'addr':x[0], 'key':x[1]} for x in nodes_keys]
 
     if args.verbose: print('[Status] Directory UP')
     try:
@@ -69,34 +69,35 @@ def main():
     except (socket.error, KeyboardInterrupt) as e:
         shut_down_directory_node()
         if args.verbose: print('[Error] Directory DOWN')
-        exit(str(e))
 
 
 
 #   INITIALIZE NODES LIST, GET PUBKEYS
 ###############################################################################
 
-# return true if node is activated
+# return true if node is listening on dir port
 def ping_node(ndn): # ndn = node domain name
-    socket.setdefaulttimeout(0.7) # (seconds) to ping node faster
-
+    
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    exit_code = s.connect_ex((ndn,PORT))
+    exit_code = s.connect_ex((ndn,args.dir_port))
     s.close()
 
-    socket.setdefaulttimeout(None) # restore default
-    
     if args.verbose: 
         node_status = "LISTENING" if not exit_code else "DOWN"
         print("Node {} is {}".format(ndn,node_status))
 
     return not exit_code
 
-# get node pubkey
 def get_node_pubkey(ndn): # ndn = node domain name
-    # TODO: fill this in
-    return "not a real pubkey"
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.connect((ndn,args.dir_port))
 
+    s.sendall(b'get_key')
+    key = s.recv(2048).decode('utf-8')
+
+    s.close()
+    
+    return key 
 
 
 #   THE DIRECTORY NODE SERVER
@@ -110,10 +111,10 @@ def run_directory_node():
         print('[Status] Connected to: {}:{}'.format(addr[0], str(addr[1])))
 
         # new thread for each connection
-        #t = threading.Thread(target=handle_path_request, args=(conn,), daemon=True) # TODO commented until reported to py3
         t = threading.Thread(target=handle_path_request, args=(conn,))
         t.setDaemon(True)
         t.start()
+
 
 def shut_down_directory_node():
     LISTEN_SOCKET.close()
@@ -123,21 +124,16 @@ def handle_path_request(conn):
     data = conn.recv(1024).decode('utf-8').rstrip()
     if args.verbose: print('[Status] Recieved path request from {}'.format(data)) 
 
-    # TODO: read path request, decrypt, enrypt with symkey
-    conn.sendall( json.dumps(get_path()).encode('utf-8') )
+
+    path = random.sample(ROUTERS, 3)
+    if args.verbose: print('[Status] Selected path: {}, {}, {}'
+                            .format(path[0]['addr'],path[1]['addr'],path[2]['addr']))
+    
+    # TODO: encrypt message
+    
+    conn.sendall(json.dumps(path).encode('utf-8'))
 
     conn.close()
-
-
-def get_path():
-    # TODO implement actual retrieval of data
-    path =  [{'addr':'lab2-1','key':'KEY_1'},
-            {'addr':'lab2-2','key':'KEY_2'},
-            {'addr':'lab2-3','key':'KEY_3'}]
-    if args.verbose: print('[Status] Selected path: {}'.format(path))
-    
-    return path
-
 
 
 #   RUN MAIN

--- a/router/onion_router.py
+++ b/router/onion_router.py
@@ -48,6 +48,7 @@ def main():
 
             # new thread for self-setup as onion_router
             t = threading.Thread(target=two_way_setup, args=(back_conn,))
+            t.setDaemon(True)
             t.start()
 
     except (socket.error, KeyboardInterrupt):
@@ -92,8 +93,8 @@ def two_way_setup(back_conn):
     
     # now that two way communication is established, pass data back and forth forever
 
-    t = threading.Thread(target=backward_transfer, args=(forw_conn,
-                        back_conn), daemon=True)
+    t = threading.Thread(target=backward_transfer, args=(forw_conn, back_conn))
+    t.setDaemon(True)
     t.start()
     forward_transfer(back_conn, forw_conn)
 

--- a/router/onion_router.py
+++ b/router/onion_router.py
@@ -1,44 +1,59 @@
-import threading
-import json
-import socket
-import argparse
+import argparse         # for command-line argument parsing
+import json             # for encoding data sent through TCP
+import threading        # for one thread per TCP connection
+import socket           # for TCP communication
 
+import sys, os.path
+sys.path.append(os.path.join(os.path.dirname(__file__), '../stealth'))
+import stealth          # for communication encryption
 
 
 #       CLI ARGS
 #########################################################
 
+# define cli positional args
 parser = argparse.ArgumentParser() # instantiate cli args parser
 
-# define cli positional args
 parser.add_argument("port", help="port to listen on", type=int)
+parser.add_argument("dir_port", help="port to listen for directory", type=int)
 parser.add_argument("-v", "--verbose",
                     help="level of logging verbose", action="store_true")
 
 args = parser.parse_args() # parse the args
 
+# TODO disabled to facilitate testing
 # validate args against conditions
-if args.port < 5551 or args.port > 5557: # 7 group members, each get a port
-    parser.error("port must satisfy: 5551 <= port <= 5557")
+#if args.port < 5551 or args.port > 5557: # 7 group members, each get a port
+#    parser.error("port must satisfy: 5551 <= port <= 5557")
 
 
 #       GLOBALS
 ########################################################
 
-PORT = args.port
 HOST = ""
+PORT = args.port
 LISTENER_SOCKET = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 LISTENER_SOCKET.bind((HOST,PORT))
 LISTENER_SOCKET.listen(50)
-DEFAULT_NEXT_PORT = 80
 
+DIR_SOCKET = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+DIR_SOCKET.bind((HOST,args.dir_port))
+DIR_SOCKET.listen(1)
 
+KEYPAIR = stealth.RSAVirtuoso()     # node's encryption key pairs
+
+DEFAULT_NEXT_PORT = 80              # default port of next hop in virtual circuit
 
 #       MAIN
 ########################################################
 
 def main():
     if args.verbose: print('[Status] Router Node UP')
+
+    dir_t = threading.Thread(target=dir_setup)
+    dir_t.setDaemon(True)
+    dir_t.start()
+
     try:
         while 1:
             # accept connection from previous ('backward') node in path
@@ -54,14 +69,32 @@ def main():
     except (socket.error, KeyboardInterrupt):
         if args.verbose: print('[Error] Router Node DOWN')
         LISTENER_SOCKET.close()
-
+        DIR_SOCKET.close()
 
 
 #       SETUP TWO TCP CONNECTIONS
 ########################################################
 
-# need to establish symkey with back_conn, connect to forw_conn
+# listen on directory dedicated port and handle its key requests
+def dir_setup():
+    while True:
+        conn , addr = DIR_SOCKET.accept()
+        req = conn.recv(2048).decode('utf-8')
+
+        # if request is empty, the directory was only pinging
+        if req == "get_key":
+            if args.verbose: print('[Status] Directory requested key')
+            resp = KEYPAIR.get_public_key().exportKey()
+            conn.sendall(resp.encode('utf-8'))
+        else:
+            if args.verbose: print('[Status] Ping from Directory')
+            
+        conn.close()
+
+
+# establish virtual circuit with 2 connection threads: backwards node and forward node
 def two_way_setup(back_conn):
+    # TODO need to establish symkey with back_conn, connect to forw_conn
     msg = back_conn.recv(2048).decode('utf-8').rstrip()
     if args.verbose: print('[Status] received SYN')
 
@@ -99,7 +132,6 @@ def two_way_setup(back_conn):
     forward_transfer(back_conn, forw_conn)
 
 
-
 #       PASS DATA FORWARD AND BACKWARD FOREVER
 ########################################################
 
@@ -114,6 +146,7 @@ def forward_transfer(back_conn, forw_conn):
         # pass it on
         forw_conn.sendall(msg.encode('utf-8'))
 
+
 def backward_transfer(forw_conn, back_conn):
     while True:
         msg = forw_conn.recv(2048).decode('utf-8').rstrip()
@@ -123,7 +156,6 @@ def backward_transfer(forw_conn, back_conn):
 
         # pass it on
         back_conn.sendall(msg.encode('utf-8'))
-
 
 
 #       RUN MAIN

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -44,7 +44,7 @@ class OriginatorSecurityEnforcer(object):
         else:
             sym = self.directorySymKey
             pubkey = self.directoryPubKey
-        msg["symkey"] = base64.encode(sym).decode('utf-8')
+        msg["symkey"] = base64.b64encode(sym).decode('utf-8')
         msg["addr"] = next_addr
         msg["port"] = next_port
         return pubkey.encrypt(json.dumps(msg))

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -44,7 +44,7 @@ class OriginatorSecurityEnforcer(object):
         else:
             sym = self.directorySymKey
             pubkey = self.directoryPubKey
-        msg["symkey"] = base64.encodebytes(sym).decode('utf-8')
+        msg["symkey"] = base64.encode(sym).decode('utf-8')
         msg["addr"] = next_addr
         msg["port"] = next_port
         return pubkey.encrypt(json.dumps(msg))


### PR DESCRIPTION
Solving Issue #25

**Summary**
- All code now runs on Python2. In case that we get Crypto on Python3 the changes are minimal:
   - raw_input() -> input()
   - b64encode -> encodebytes()
 
- Directory - Routers key transfer is done in separate thread:
   - Routers now have a CL parameter to specify the port to listen for Directory requests
   - Directory can ping and request key throught the same port
   - Virtual Circuit setup didn't change
- `onion_client.py`, `onion_router.py`, `onion_destination.py`,  `onion_directory.py` have been homogenized to follow the same logical and naming conventions
- All changes were tested
