### PR TITLE
Crypto routing 28

### DIFF
--- a/client/onion_client.py
+++ b/client/onion_client.py
@@ -53,7 +53,7 @@ ORIGINATOR_CIPHER = OriginatorSecurityEnforcer()
 
 def main():
     if args.verbose: print('[Status] Client Node UP')
-
+    
     try:
         run_client_node()
     except (socket.error, KeyboardInterrupt, Exception) as e:
@@ -70,7 +70,7 @@ def run_client_node():
 
     if args.verbose: print('[Status] Obtaining path...')
     path = get_path()
-    path.append({'addr' : args.destination, 'key': 'DST_KEY'}) # TODO does dst have a key?
+    path.append({'addr' : args.destination, 'key': 'DST_KEY', 'port': args.destination_port}) # TODO does dst have a key?
     if args.verbose: print('[Status] Path: {}'.format(path))
 
     SENDER_SOCKET.connect((path[0]['addr'],PORT))
@@ -154,7 +154,7 @@ def setup_vc(path, conn):
         if i != 3: nextaddr = ORIGINATOR_CIPHER.path[i][0]
         else: nextaddr = args.destination
         print('Creating symkey msg')
-        symkey_msg = ORIGINATOR_CIPHER.create_symkey_msg(i, nextaddr, PORT)
+        symkey_msg = ORIGINATOR_CIPHER.create_symkey_msg(i, nextaddr, path[i]["port"])
         print('Creating onion')
         setup_onion = ORIGINATOR_CIPHER.create_onion(i, symkey_msg)
         if args.verbose: print('[Status] setup_onion: {}'.format(setup_onion))

--- a/client/onion_client.py
+++ b/client/onion_client.py
@@ -116,10 +116,14 @@ def get_path():
 
     pubkey = dir_sock.recv(6144).decode('utf-8').rstrip()
     ORIGINATOR_CIPHER.directoryPubKey = RSAVirtuoso(RSA.importKey(pubkey))
-    dir_sock.sendall('get me a path')
+    msg = ORIGINATOR_CIPHER.create_symkey_msg(0, '', '')
+    if args.verbose:
+        print('Sending message: ' + msg)
+    dir_sock.sendall(msg.encode('utf-8'))
 
     data = dir_sock.recv(6144).decode('utf-8').rstrip()
-    path = json.loads(data)
+
+    path = json.loads(ORIGINATOR_CIPHER.decipher_response(0,data))
 
     dir_sock.close()
 

--- a/client/onion_client.py
+++ b/client/onion_client.py
@@ -68,8 +68,6 @@ def main():
 ###############################################################################
 
 def run_client_node():
-    global ORIGINATOR_CIPHER
-
     if args.verbose: print('[Status] Obtaining path...')
     path = get_path()
     if args.destination_port:
@@ -90,20 +88,18 @@ def run_client_node():
     if args.verbose: print('[Status] Virtual Circuit UP')
 
     while True:
-        msg = raw_input('Enter Message > ')
+        msg = raw_input('\nEnter Message > ')
         onion = ORIGINATOR_CIPHER.create_onion(4, msg)
         SENDER_SOCKET.sendall(onion.encode('utf-8'))
         #Wait for a short period for a response. 
         #Looks nicer to see the response before the next prompt.
-        time.sleep(0.5) 
+        time.sleep(0.3) 
 
 def shut_down_client_node():
     SENDER_SOCKET.close()
 
 
 def get_path():
-    global ORIGINATOR_CIPHER
-
     dir_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     dir_sock.connect((DIRECTORY_NODE,PORT))
 
@@ -132,8 +128,6 @@ def get_path():
 
 # send setup onions to all the nodes in path through the conn socket
 def setup_vc(path, conn):
-    global ORIGINATOR_CIPHER
-
     #i represents depth, the amount of nodes deep into the path the dest is
     for i in range(1,4):
         if i != 3: nextaddr = ORIGINATOR_CIPHER.path[i][0]
@@ -156,7 +150,7 @@ def handle_response(conn):
         msg = conn.recv(2048).decode('utf-8').rstrip()
 
         msg = ORIGINATOR_CIPHER.decipher_response(3, msg) #Depth is 3 because all 3 onion nodes encrypted
-        print('\nReply from {}: {}'.format(args.destination, msg))
+        print('Reply from {}: {}'.format(args.destination, msg))
 
 
 #   RUN MAIN

--- a/client/onion_client.py
+++ b/client/onion_client.py
@@ -101,6 +101,9 @@ def get_path():
 
     dir_sock.sendall(socket.gethostname().encode('utf-8'))
 
+    pubkey = dir_sock.recv(6144).decode('utf-8').rstrip()
+    print('Directory\'s pubkey: ' + pubkey)
+
     data = dir_sock.recv(6144).decode('utf-8').rstrip()
     path = json.loads(data)
 

--- a/client/onion_client.py
+++ b/client/onion_client.py
@@ -3,6 +3,7 @@ import json                 # for encoding data sent through TCP
 import random               # for random path selection
 import socket               # for TCP communication
 import threading            # for one thread per TCP connection
+import time                 # for sleep between message prompts
 
 from Crypto.PublicKey import RSA
 
@@ -44,6 +45,7 @@ PORT = args.onion_port
 SENDER_SOCKET = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
 DIRECTORY_NODE = 'cs-1'            
+DEFAULT_PORT = 80
 
 ORIGINATOR_CIPHER = OriginatorSecurityEnforcer()
 
@@ -70,7 +72,10 @@ def run_client_node():
 
     if args.verbose: print('[Status] Obtaining path...')
     path = get_path()
-    path.append({'addr' : args.destination, 'key': 'DST_KEY', 'port': args.destination_port}) # TODO does dst have a key?
+    if args.destination_port:
+        port = args.destination_port
+    else: port = DEFAULT_PORT
+    path.append({'addr' : args.destination, 'key': 'DST_KEY', 'port': port}) 
     if args.verbose: print('[Status] Path: {}'.format(path))
 
     SENDER_SOCKET.connect((path[0]['addr'],PORT))
@@ -82,28 +87,15 @@ def run_client_node():
     t.setDaemon(True)
     t.start()
 
-    # send first data onion 
-#    msg = raw_input('Enter Message > ')
-
-#    first_onion = encapsulate(path[3]['addr'], path[3]['key'], 
-#                                msg, args.destination_port)
-
-#    if args.verbose: print('[Data] First_onion: {}'.format(first_onion))
-    
-    # TODO encrypt data
-    
-#    SENDER_SOCKET.sendall(json.dumps(first_onion).encode('utf-8'))
-    
     if args.verbose: print('[Status] Virtual Circuit UP')
 
     while True:
         msg = raw_input('Enter Message > ')
-            
-        # TODO encrypt
         onion = ORIGINATOR_CIPHER.create_onion(4, msg)
-
         SENDER_SOCKET.sendall(onion.encode('utf-8'))
-
+        #Wait for a short period for a response. 
+        #Looks nicer to see the response before the next prompt.
+        time.sleep(0.5) 
 
 def shut_down_client_node():
     SENDER_SOCKET.close()
@@ -118,8 +110,9 @@ def get_path():
     dir_sock.sendall(socket.gethostname().encode('utf-8'))
 
     pubkey = dir_sock.recv(6144).decode('utf-8').rstrip()
+    # Create RSAVirtuoso instance from the exported key sent from the directory node
     ORIGINATOR_CIPHER.directoryPubKey = RSAVirtuoso(RSA.importKey(pubkey))
-    msg = ORIGINATOR_CIPHER.create_symkey_msg(0, '', '')
+    msg = ORIGINATOR_CIPHER.create_symkey_msg(0, '', '') #Depth is 0 since we're talking to the directory
     if args.verbose:
         print('Sending message: ' + msg)
     dir_sock.sendall(msg.encode('utf-8'))
@@ -139,51 +132,30 @@ def get_path():
 
 # send setup onions to all the nodes in path through the conn socket
 def setup_vc(path, conn):
-    # get ACK from first node
-#    conn.sendall(b'SYN')
-#    response = conn.recv(1024).decode('utf-8').rstrip()
-#    if response != 'ACK': return false
-#    if args.verbose: print('[Status] ACK recieved')
-
     global ORIGINATOR_CIPHER
 
-    # get ACK for remaining internal nodes
+    #i represents depth, the amount of nodes deep into the path the dest is
     for i in range(1,4):
-#        setup_onion = encapsulate(path[i]['addr'], path[i]['key'], 
-#                                'SYN', args.onion_port)
         if i != 3: nextaddr = ORIGINATOR_CIPHER.path[i][0]
         else: nextaddr = args.destination
-        print('Creating symkey msg')
         symkey_msg = ORIGINATOR_CIPHER.create_symkey_msg(i, nextaddr, path[i]["port"])
-        print('Creating onion')
         setup_onion = ORIGINATOR_CIPHER.create_onion(i, symkey_msg)
         if args.verbose: print('[Status] setup_onion: {}'.format(setup_onion))
-        
-        # TODO encrypt data
         
         conn.sendall(json.dumps(setup_onion).encode('utf-8'))
         if args.verbose: print('[Status] received encrypted response..')
         response = conn.recv(1024).decode('utf-8').rstrip()
         if i > 1 : response = ORIGINATOR_CIPHER.decipher_response(i-1, response)
-#        if response != 'ACK': return false
-#        if args.verbose: print('[Status] ACK recieved')
+        if response != 'ACK': return false
+        if args.verbose: print('[Status] ACK received')
     
     return True
-
-
-def encapsulate(addr, key, next_node, port=None):
-    onion = {'addr': addr, 'key': key, 'next': next_node} 
-    if port: onion['port'] = port
-
-    return onion
-
 
 def handle_response(conn):
     while True:
         msg = conn.recv(2048).decode('utf-8').rstrip()
 
-        # TODO decrypt
-        msg = ORIGINATOR_CIPHER.decipher_response(3, msg)
+        msg = ORIGINATOR_CIPHER.decipher_response(3, msg) #Depth is 3 because all 3 onion nodes encrypted
         print('\nReply from {}: {}'.format(args.destination, msg))
 
 

--- a/client/onion_client.py
+++ b/client/onion_client.py
@@ -162,7 +162,9 @@ def setup_vc(path, conn):
         # TODO encrypt data
         
         conn.sendall(json.dumps(setup_onion).encode('utf-8'))
+        if args.verbose: print('[Status] received encrypted response..')
         response = conn.recv(1024).decode('utf-8').rstrip()
+        if i > 1 : response = ORIGINATOR_CIPHER.decipher_response(i-1, response)
 #        if response != 'ACK': return false
 #        if args.verbose: print('[Status] ACK recieved')
     
@@ -181,8 +183,8 @@ def handle_response(conn):
         msg = conn.recv(2048).decode('utf-8').rstrip()
 
         # TODO decrypt
-
-        print('\nReply from {}: {}'.format('ADD SRC',msg))
+        msg = ORIGINATOR_CIPHER.decipher_response(3, msg)
+        print('\nReply from {}: {}'.format(args.destination, msg))
 
 
 #   RUN MAIN

--- a/client/onion_client.py
+++ b/client/onion_client.py
@@ -66,6 +66,8 @@ def main():
 ###############################################################################
 
 def run_client_node():
+    global ORIGINATOR_CIPHER
+
     if args.verbose: print('[Status] Obtaining path...')
     path = get_path()
     path.append({'addr' : args.destination, 'key': 'DST_KEY'}) # TODO does dst have a key?
@@ -81,16 +83,16 @@ def run_client_node():
     t.start()
 
     # send first data onion 
-    msg = raw_input('Enter Message > ')
+#    msg = raw_input('Enter Message > ')
 
-    first_onion = encapsulate(path[3]['addr'], path[3]['key'], 
-                                msg, args.destination_port)
+#    first_onion = encapsulate(path[3]['addr'], path[3]['key'], 
+#                                msg, args.destination_port)
 
-    if args.verbose: print('[Data] First_onion: {}'.format(first_onion))
+#    if args.verbose: print('[Data] First_onion: {}'.format(first_onion))
     
     # TODO encrypt data
     
-    SENDER_SOCKET.sendall(json.dumps(first_onion).encode('utf-8'))
+#    SENDER_SOCKET.sendall(json.dumps(first_onion).encode('utf-8'))
     
     if args.verbose: print('[Status] Virtual Circuit UP')
 
@@ -98,8 +100,9 @@ def run_client_node():
         msg = raw_input('Enter Message > ')
             
         # TODO encrypt
+        onion = ORIGINATOR_CIPHER.create_onion(4, msg)
 
-        SENDER_SOCKET.sendall(msg.encode('utf-8'))
+        SENDER_SOCKET.sendall(onion.encode('utf-8'))
 
 
 def shut_down_client_node():
@@ -145,7 +148,7 @@ def setup_vc(path, conn):
     global ORIGINATOR_CIPHER
 
     # get ACK for remaining internal nodes
-    for i in range(1,3):
+    for i in range(1,4):
 #        setup_onion = encapsulate(path[i]['addr'], path[i]['key'], 
 #                                'SYN', args.onion_port)
         if i != 3: nextaddr = ORIGINATOR_CIPHER.path[i][0]

--- a/directory/onion_directory.py
+++ b/directory/onion_directory.py
@@ -124,6 +124,10 @@ def handle_path_request(conn):
     data = conn.recv(1024).decode('utf-8').rstrip()
     if args.verbose: print('[Status] Recieved path request from {}'.format(data)) 
 
+    pubkey = KEYPAIR.get_public_key().exportKey()
+    conn.sendall(pubkey)
+    
+    data = conn.recv(1024).decode('utf-8').rstrip()
 
     path = random.sample(ROUTERS, 3)
     if args.verbose: print('[Status] Selected path: {}, {}, {}'

--- a/directory/onion_directory.py
+++ b/directory/onion_directory.py
@@ -131,17 +131,15 @@ def handle_path_request(conn):
     
     data = conn.recv(2048).decode('utf-8').rstrip()
 
-    symkey = KEYPAIR.decrypt(data)
-    if args.verbose: 
-        print('Received symkey: ' + symkey)
+    condata = KEYPAIR.extract_path_data(data)
 
     path = random.sample(ROUTERS, 3)
     if args.verbose: print('[Status] Selected path: {}, {}, {}'
                             .format(path[0]['addr'],path[1]['addr'],path[2]['addr']))
 
     rng = AESGenerator()
-    rng.reseed(symkey.encode('utf-8'))
-    aesmachine = AESProdigy(symkey, rng.pseudo_random_data(16))
+    rng.reseed(condata[0])
+    aesmachine = AESProdigy(condata[0], rng.pseudo_random_data(16))
     
     # TODO: encrypt message
     ciphertext = aesmachine.encrypt(json.dumps(path))

--- a/directory/onion_directory.py
+++ b/directory/onion_directory.py
@@ -63,7 +63,7 @@ def main():
     nodes = ['lab2-{}'.format(i) for i in range(1, MAX_NODES+1)]
     up_nodes = list( filter(ping_node, nodes) ) 
     nodes_keys = zip(up_nodes, map(get_node_pubkey, up_nodes))
-    ROUTERS = [{'addr':x[0], 'key':x[1]} for x in nodes_keys]
+    ROUTERS = [{'addr':x[0], 'key':x[1], 'port': PORT} for x in nodes_keys]
 
     if args.verbose: print('[Status] Directory UP')
     try:

--- a/directory/onion_directory.py
+++ b/directory/onion_directory.py
@@ -65,6 +65,11 @@ def main():
     nodes_keys = zip(up_nodes, map(get_node_pubkey, up_nodes))
     ROUTERS = [{'addr':x[0], 'key':x[1], 'port': PORT} for x in nodes_keys]
 
+    if len(ROUTERS) < 3:
+        print('[Status] Not enough onion nodes running in network')
+        print('[Error] Directory DOWN')
+        sys.exit(1)
+
     if args.verbose: print('[Status] Directory UP')
     try:
         run_directory_node()
@@ -140,8 +145,6 @@ def handle_path_request(conn):
     rng = AESGenerator()
     rng.reseed(condata[0])
     aesmachine = AESProdigy(condata[0], rng.pseudo_random_data(16))
-    
-    # TODO: encrypt message
     ciphertext = aesmachine.encrypt(json.dumps(path))
     
     conn.sendall(ciphertext.encode('utf-8'))

--- a/router/onion_router.py
+++ b/router/onion_router.py
@@ -101,7 +101,7 @@ def two_way_setup(back_conn):
 
     # TODO need to establish symkey with back_conn, connect to forw_conn
     msg = back_conn.recv(2048).decode('utf-8').rstrip()
-    if args.verbose: print('[Status] received SYN')
+    if args.verbose: print('[Status] received estab: ' + msg)
 
     # (TODO:decrypt data, initialize+respond with symkey. for now send 'ACK')
     pathdata = KEYPAIR.extract_path_data(msg)
@@ -114,6 +114,7 @@ def two_way_setup(back_conn):
 #    if args.verbose: print('[Status] First data onion: {}'.format(msg))
 
     # (TODO:decrypt)
+    if args.verbose: print('[Status] received next: ' + msg)
     msg = ONION_CIPHER.peel_layer(msg)
 
     # parse onion to find out who to send to and what to send
@@ -129,7 +130,7 @@ def two_way_setup(back_conn):
     forw_conn.connect((pathdata[1], pathdata[2]))
     if args.verbose: print('[Status] Connected.')
     
-    if args.verbose: print('[Status] Sending: {} To: {}'.format(msg_next, msg_addr))
+    if args.verbose: print('[Status] Sending: {} To: {}'.format(msg, pathdata[1]))
     forw_conn.sendall(msg.encode('utf-8'))
     
     # now that two way communication is established, pass data back and forth forever
@@ -152,7 +153,7 @@ def forward_transfer(back_conn, forw_conn):
         # (TODO: decrypt)
 
         # pass it on
-        forw_conn.sendall(msg.encode('utf-8'))
+        forw_conn.sendall(ONION_CIPHER.peel_layer(msg).encode('utf-8'))
 
 
 def backward_transfer(forw_conn, back_conn):

--- a/router/onion_router.py
+++ b/router/onion_router.py
@@ -126,7 +126,7 @@ def two_way_setup(back_conn):
 
     # connect to forw_conn and pass along data from back_conn
     forw_conn = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    if args.verbose: print('[Status] Connecting to next onion node...')
+    if args.verbose: print('[Status] Trying to connect to {} on port {}...'.format(pathdata[1], pathdata[2]))
     forw_conn.connect((pathdata[1], pathdata[2]))
     if args.verbose: print('[Status] Connected.')
     

--- a/router/onion_router.py
+++ b/router/onion_router.py
@@ -145,6 +145,7 @@ def two_way_setup(back_conn):
 ########################################################
 
 def forward_transfer(back_conn, forw_conn):
+    global ONION_CIPHER
     while True:
         msg = back_conn.recv(2048).decode('utf-8').rstrip()
         
@@ -162,6 +163,7 @@ def backward_transfer(forw_conn, back_conn):
 
         if args.verbose: print('[Data] From fwd_conn: {}'.format(msg))
         # (TODO: encrypt)
+        msg = ONION_CIPHER.add_layer(msg)
 
         # pass it on
         back_conn.sendall(msg.encode('utf-8'))

--- a/router/onion_router.py
+++ b/router/onion_router.py
@@ -97,8 +97,6 @@ def dir_setup():
 
 # establish virtual circuit with 2 connection threads: backwards node and forward node
 def two_way_setup(back_conn):
-    global ONION_CIPHER
-
     # Wait for first contact
     # First message will contain (symkey, addr of next node, port of next node)
     msg = back_conn.recv(2048).decode('utf-8').rstrip()
@@ -132,7 +130,6 @@ def two_way_setup(back_conn):
 ########################################################
 
 def forward_transfer(back_conn, forw_conn):
-    global ONION_CIPHER
     while True:
         msg = back_conn.recv(2048).decode('utf-8').rstrip()
         

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -15,6 +15,7 @@ MAX_MESSAGE_SIZE = 4096
 class OriginatorSecurityEnforcer(object):
     def __init__(self):
         self.path = []
+        self.gens = []
         self.directorySymKey = stealth.get_random_key(16)
         self.directoryGen = AESGenerator()
         self.directoryGen.reseed(self.directorySymKey)

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -15,16 +15,20 @@ MAX_MESSAGE_SIZE = 4096
 class OriginatorSecurityEnforcer(object):
     def __init__(self):
         circuit = dummy_get_onion_circuit()
-        self.path = circuit[0]
-        self.onions = circuit[1]
-        self.gens = [AESGenerator() for i in range(len(self.path))]
+        self.path = []
+#        self.onions = circuit[1]
         self.directorySymKey = stealth.get_random_key(16)
         self.directoryGen = AESGenerator()
         self.directoryGen.reseed(self.directorySymKey)
         self.directoryPubKey = None
+        self.pubkeys = []
+
+    def set_path(self, pathdata):
+        for c in pathdata:
+            self.path.append((c["addr"], stealth.get_random_key(16), c["key"]))
+        self.gens = [AESGenerator() for i in range(len(self.path))]
         for c in range(len(self.path)):
             self.gens[c].reseed(self.path[c][1])
-        self.pubkeys = []
 
     def get_onions(self): # For testing before network only
         return self.onions
@@ -54,13 +58,13 @@ class OriginatorSecurityEnforcer(object):
     # Set depth=0 if talking to the directory node, depth=1 for the first node in the path...etc
     def create_onion(self, depth, msg):
         ciphertext = msg
-        if depth < 1:
+        if depth == 0:
             machine = AESProdigy(self.directorySymKey, self.directoryGen.pseudo_random_data(16))
             ciphertext = machine.encrypt(ciphertext)
         else:
             if depth > len(self.path):
                 depth = len(self.path)
-            for c in range(depth-1, -1, -1):
+            for c in range(depth-2, -1, -1):
                 machine = AESProdigy(self.path[c][1], self.gens[c].pseudo_random_data(16))
                 ciphertext = machine.encrypt(ciphertext)
         return ciphertext

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -70,7 +70,7 @@ class OriginatorSecurityEnforcer(object):
     # Ex, if passed through all onion nodes, depth=amount of nodes in path
     def decipher_response(self, depth, msg):
         if depth < 1:
-            machine = AESProdify(self.directorySymKey, self.directoryGen.pseudo_random_data(16))
+            machine = AESProdigy(self.directorySymKey, self.directoryGen.pseudo_random_data(16))
             msg = machine.decrypt(msg)
         else:
             for c in range(depth):

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -14,9 +14,7 @@ MAX_MESSAGE_SIZE = 4096
 
 class OriginatorSecurityEnforcer(object):
     def __init__(self):
-        circuit = dummy_get_onion_circuit()
         self.path = []
-#        self.onions = circuit[1]
         self.directorySymKey = stealth.get_random_key(16)
         self.directoryGen = AESGenerator()
         self.directoryGen.reseed(self.directorySymKey)
@@ -29,9 +27,6 @@ class OriginatorSecurityEnforcer(object):
         self.gens = [AESGenerator() for i in range(len(self.path))]
         for c in range(len(self.path)):
             self.gens[c].reseed(self.path[c][1])
-
-    def get_onions(self): # For testing before network only
-        return self.onions
 
     def get_path(self):
         return self.path
@@ -64,7 +59,7 @@ class OriginatorSecurityEnforcer(object):
         else:
             if depth > len(self.path) + 1:
                 depth = len(self.path)
-            for c in range(depth-2, -1, -1):
+            for c in range(depth-2, -1, -1): #Never want to encrypt the destination's message
                 machine = AESProdigy(self.path[c][1], self.gens[c].pseudo_random_data(16))
                 ciphertext = machine.encrypt(ciphertext)
         return ciphertext

--- a/stealth/onion.py
+++ b/stealth/onion.py
@@ -62,7 +62,7 @@ class OriginatorSecurityEnforcer(object):
             machine = AESProdigy(self.directorySymKey, self.directoryGen.pseudo_random_data(16))
             ciphertext = machine.encrypt(ciphertext)
         else:
-            if depth > len(self.path):
+            if depth > len(self.path) + 1:
                 depth = len(self.path)
             for c in range(depth-2, -1, -1):
                 machine = AESProdigy(self.path[c][1], self.gens[c].pseudo_random_data(16))

--- a/stealth/test.py
+++ b/stealth/test.py
@@ -49,6 +49,7 @@ class TestSymkeyCommunication(unittest.TestCase):
         addr = 'cs-1.cs.mcgill.ca'
         port = 5551
         originator = OriginatorSecurityEnforcer()
+        originator.path = [('blah', stealth.get_random_key(16), 5551) for c in range(0,1)]
         nodekey = RSAVirtuoso()
         originator.set_pubkeys([RSAVirtuoso(nodekey.key.publickey())])
         msg = originator.create_symkey_msg(1, addr, port)
@@ -60,25 +61,27 @@ class TestDataCommunication(unittest.TestCase):
     def test_basic_data_message(self):
         message = 'Hello, Newman'
         originator = OriginatorSecurityEnforcer()
+        originator.set_path([{'addr': 'blah', 'port': 5551, 'key': stealth.get_random_key(16)}])
         node = OnionNodeSecurityEnforcer()
         nodekey = RSAVirtuoso()
         originator.set_pubkeys([RSAVirtuoso(nodekey.key.publickey())])
         msg = originator.create_symkey_msg(1, 'cs-1.cs.mcgill.ca', 5551)
         data = nodekey.extract_path_data(msg)
         node.set_key(data[0])
-        ciphertext = originator.create_onion(1, message)
+        ciphertext = originator.create_onion(2, message)
         msg = node.peel_layer(ciphertext)
         self.assertEqual(msg, message)
 
-    def test_basic_message_retrieval(self):
-        message = 'Hello, Newman'
-        originator = OriginatorSecurityEnforcer()
-        nodes = originator.get_onions()
-        cipher = message
-        for c in range(len(nodes)-1, -1, -1):
-            cipher = nodes[c].add_layer(cipher)
-        retrieved = originator.decipher_response(len(nodes), cipher)
-        self.assertEqual(message, retrieved)
+# Obsolete now that crypto works over the network
+#    def test_basic_message_retrieval(self):
+#        message = 'Hello, Newman'
+#        originator = OriginatorSecurityEnforcer()
+#        nodes = originator.get_onions()
+#        cipher = message
+#        for c in range(len(nodes)-1, -1, -1):
+#            cipher = nodes[c].add_layer(cipher)
+#        retrieved = originator.decipher_response(len(nodes), cipher)
+#        self.assertEqual(message, retrieved)
 
 #Obsolete, for now
 #class TestEstablishment(unittest.TestCase):


### PR DESCRIPTION
This pull request is for the base implementation of cryptography in the onion network.
Here's a brief overview of what was done:

* Implemented handshake between the onion client and the directory node to establish a shared symmetric key
* Updated establishment protocol and encrypted the virtual circuit establishment process
* Updated the onion-creation function and implemented encrypted message passing
* Implemented propagated encryption of the response from the exit node back to the originator
* Decryption of response at the originator
* Updated unit tests after some slight changes to the `stealth/` APIs

I did make three design choices that I wanted to point out, to make sure you guys agree with them.
* Someone left a comment where our routers sent an 'ACK' back towards the originator saying we should send a symkey instead. I never entirely understood the reasoning behind this. I imagine it was some sort of check to make sure the right node is establishing the connection and/or to make sure no funny business had occurred. Instead of doing this, my implementation encrypts the 'ACK's before sending them back towards the originator (as per the onion routing paradigm). If the originator is able to decrypt all of its responses during the establishment process and realize that each one had sent an ACK, then it is effectively also concluding that the right symkeys were used to encrypt the response in the first place. This approach was simpler, and as far as I'm concerned, it has the same functionality as sending back the symkeys.
* I took the liberty to include a sleep after sending each message. Without it, the client would display the response message after the next prompt, so when you type the next message it won't appear next to the prompt. I found this a little ugly and confusing at first. To solve this, I included a 300ms sleep after each message is sent, which should usually give enough time for the response to be shown before the next prompt. In the case where the server that you're communicating with isn't responding, the timeout isn't painfully long. However, this is a purely cosmetic fix, so if you don't like it I will change it back. 
* I modified the main function of the `onion_directory.py` to `sys.exit(1)` if `len(ROUTERS) < 3`. Without this, the directory node starts running and waiting for connections and such, but when an originator contacts the directory node it will crash because it tries to select a random path of 3 nodes. 

Though crypto is absolutely in effect now, it is not perfect. Unfortunately, base64 encoding (which is done on ciphertext) yields an encoding that is larger than its input. This causes forward messages to decrease in length throughout the network (from the base64 decoding) and increases the length of backward messages (from base64 encoding). Another encoding may need to be used to resolve this. On the bright side, AES itself does output a ciphertext of the same length as its input, so if the base64 issue can be avoided then the conclusions of #16 are still valid. Regardless, I think the changes made considering #16 still make the process simpler and more robust. 

That being said, I still think it's appropriate to merge this, because for the purpose of the project this implements a sufficient amount of security, and provides something more or less complete to be tested.

Resolves #28 